### PR TITLE
fix: 💄 Highlight simple identifiers separately to fix inconsistent highlighting

### DIFF
--- a/src/components/java/patch-notes.tsx
+++ b/src/components/java/patch-notes.tsx
@@ -311,10 +311,20 @@ function isResourceTag(code: string) {
   return /^#[a-z0-9._-]+(:[a-z0-9._-]+)?$/.test(code);
 }
 
+const keywords = ["true", "false"];
+
+function isSimpleIdentifier(code: string) {
+  return !keywords.includes(code) && /^[a-zA-Z][a-zA-Z0-9._-]*$/.test(code);
+}
+
 function parseCodeInline(domNode: Element) {
   return parseCode(domNode, {
     lang(code: string) {
-      return isResourceTag(code) ? "resource-tag" : "mcfunction";
+      return isResourceTag(code)
+        ? "resource_tag"
+        : isSimpleIdentifier(code)
+          ? "simple_id"
+          : "mcfunction";
     },
     className: "rounded-md px-1",
     elem: "span",

--- a/src/server/highlighting/generic.ts
+++ b/src/server/highlighting/generic.ts
@@ -1,0 +1,22 @@
+import { type LanguageRegistration } from "shiki";
+
+export const simpleIdentifierTmLang: LanguageRegistration = {
+  name: "Simple identifier",
+  scopeName: "source.id",
+  patterns: [
+    {
+      include: "#root",
+    },
+  ],
+  repository: {
+    root: {
+      captures: {
+        "0": {
+          name: "variable.other.mcfunction",
+        },
+      },
+      match: "[a-zA-Z][a-zA-Z0-9._-]*",
+      name: "meta.property_key",
+    },
+  },
+};

--- a/src/server/highlighting/highlighter.ts
+++ b/src/server/highlighting/highlighter.ts
@@ -8,6 +8,7 @@ import {
   type SpecialLanguage,
 } from "shiki";
 import { getMcfunctionTmLang, tagTmLang } from "./mcfunction";
+import { simpleIdentifierTmLang } from "./generic";
 import { flavorEntries } from "@catppuccin/palette";
 
 const themes = Object.fromEntries(
@@ -27,7 +28,7 @@ export function initHighlighter() {
     _initPromise = (async () => {
       const mcfunctionTmLang = await getMcfunctionTmLang();
       const highlighter = await createHighlighter({
-        langs: [mcfunctionTmLang, tagTmLang],
+        langs: [mcfunctionTmLang, tagTmLang, simpleIdentifierTmLang],
         themes: Object.values(themes),
       });
       highlightInfo = {
@@ -42,7 +43,8 @@ export function initHighlighter() {
 
 export type Language =
   | "mcfunction"
-  | "resource-tag"
+  | "resource_tag"
+  | "simple_id"
   | BundledLanguage
   | SpecialLanguage;
 
@@ -84,7 +86,8 @@ export function highlightToHtml(
 
   const langMap: Partial<Record<Language, string>> = {
     mcfunction: mcfunctionTmLang.name,
-    "resource-tag": tagTmLang.name,
+    resource_tag: tagTmLang.name,
+    simple_id: simpleIdentifierTmLang.name,
   };
 
   return highlighter.codeToHtml(code, {


### PR DESCRIPTION
Unfortunately this does mean that command names get highlighted like simple identifiers, but there's no good way to differentiate since simple identifiers and command names often follow the same syntax