### PR TITLE
Group each version per release in the version bar

### DIFF
--- a/src/app/java/changelog/layout.tsx
+++ b/src/app/java/changelog/layout.tsx
@@ -20,9 +20,10 @@ import {
 import { Button } from "~/components/ui/button";
 import ReleaseVersionLinkSet from "~/components/java/release-version-link-set";
 import "~/styles/game-versions.css";
+import { type ReleaseVersionEntry } from "~/components/java/version-link";
 
 export default async function ChangelogLayout({
-  children
+  children,
 }: {
   children: React.ReactNode;
 }) {
@@ -89,19 +90,6 @@ export default async function ChangelogLayout({
   );
 }
 
-export interface VersionEntry {
-  name: string;
-  url: string;
-  title: string;
-  description: string;
-  image: { title: string; url: string; };
-}
-
-export interface ReleaseVersionEntry extends VersionEntry {
-  nonReleaseVersions: VersionEntry[];
-  isLatest: boolean;
-}
-
 function VersionLinks({
   versions,
   type,
@@ -111,7 +99,7 @@ function VersionLinks({
   type: string;
   className?: string;
 }) {
-  let orderedVersions: ReleaseVersionEntry[] = [
+  const orderedVersions: ReleaseVersionEntry[] = [
     {
       name: "Latest",
       url: "",
@@ -122,7 +110,7 @@ function VersionLinks({
       isLatest: true
     }
   ];
-  for (let version of versions) {
+  for (const version of versions) {
     if (version.type === "release") {
       orderedVersions.push({
         name: version.version,

--- a/src/components/java/release-version-link-set.tsx
+++ b/src/components/java/release-version-link-set.tsx
@@ -1,15 +1,14 @@
 "use client";
 
-import { ReleaseVersionEntry } from "~/app/java/changelog/layout";
-import VersionLink from "./version-link";
 import { usePathname } from "next/navigation";
+import VersionLink, { type ReleaseVersionEntry } from "./version-link";
 
 export default function ReleaseVersionLinkSet({release, type, className}: {
   release: ReleaseVersionEntry;
   type: string;
   className: string;
 }) {
-  let selectedVersion: string = getVersion();
+  const selectedVersion = useVersion();
   return (
     <div className="major-version">
       <VersionLink version={release} selected={release.name === selectedVersion} className={className} />
@@ -26,13 +25,13 @@ export default function ReleaseVersionLinkSet({release, type, className}: {
   );
 }
 
-function getVersion(): string {
-  const prefix: string = "java/changelog/";
+function useVersion(): string {
+  const prefix = "java/changelog/";
   const pathname = usePathname();
   if (pathname === prefix) {
     return "";
   }
-  let probableVersion: string = pathname.substring(prefix.length);
+  const probableVersion = pathname.substring(prefix.length);
   if (probableVersion.startsWith("/")) {
     return probableVersion.substring(1);
   }
@@ -46,10 +45,5 @@ function containsVersion(release: ReleaseVersionEntry, version: string): boolean
   if (release.name === version) {
     return true;
   }
-  for (let nonRelease of release.nonReleaseVersions) {
-    if (nonRelease.name === version) {
-      return true;
-    }
-  }
-  return false;
+  return release.nonReleaseVersions.some(nonRelease => nonRelease.name === version);
 }

--- a/src/components/java/release-version-link-set.tsx
+++ b/src/components/java/release-version-link-set.tsx
@@ -3,7 +3,11 @@
 import { usePathname } from "next/navigation";
 import VersionLink, { type ReleaseVersionEntry } from "./version-link";
 
-export default function ReleaseVersionLinkSet({release, type, className}: {
+export default function ReleaseVersionLinkSet({
+  release,
+  type,
+  className,
+}: {
   release: ReleaseVersionEntry;
   type: string;
   className: string;

--- a/src/components/java/release-version-link-set.tsx
+++ b/src/components/java/release-version-link-set.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { ReleaseVersionEntry } from "~/app/java/changelog/layout";
+import VersionLink from "./version-link";
+import { usePathname } from "next/navigation";
+
+export default function ReleaseVersionLinkSet({release, type, className}: {
+  release: ReleaseVersionEntry;
+  type: string;
+  className: string;
+}) {
+  let selectedVersion: string = getVersion();
+  return (
+    <div className="major-version">
+      <VersionLink version={release} selected={release.name === selectedVersion} className={className} />
+      {
+        release.nonReleaseVersions.length > 0 && <>
+          <input type="checkbox" id={`major-version-${release.name}-${type}`} defaultChecked={containsVersion(release, selectedVersion)}></input>
+          <label className="major-version-button" htmlFor={`major-version-${release.name}-${type}`}></label>
+          <div className="major-version-body">
+            {release.nonReleaseVersions.map(nonReleaseVersion => <VersionLink key={nonReleaseVersion.name} version={nonReleaseVersion} selected={nonReleaseVersion.name === selectedVersion} className={className} />)}
+          </div>
+        </>
+      }
+    </div>
+  );
+}
+
+function getVersion(): string {
+  const prefix: string = "java/changelog/";
+  const pathname = usePathname();
+  if (pathname === prefix) {
+    return "";
+  }
+  let probableVersion: string = pathname.substring(prefix.length);
+  if (probableVersion.startsWith("/")) {
+    return probableVersion.substring(1);
+  }
+  return probableVersion;
+}
+
+function containsVersion(release: ReleaseVersionEntry, version: string): boolean {
+  if (release.isLatest && version === "") {
+    return true;
+  }
+  if (release.name === version) {
+    return true;
+  }
+  for (let nonRelease of release.nonReleaseVersions) {
+    if (nonRelease.name === version) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/components/java/version-link.tsx
+++ b/src/components/java/version-link.tsx
@@ -16,7 +16,7 @@ import type { ClassValue } from "clsx";
 export default function VersionLink({
   version,
   className = "px-3 py-1",
-  selected
+  selected,
 }: {
   version: VersionEntry;
   className?: ClassValue;

--- a/src/components/java/version-link.tsx
+++ b/src/components/java/version-link.tsx
@@ -8,41 +8,35 @@ import {
 } from "~/components/ui/hover-card";
 import Link from "next/link";
 import { cn } from "~/lib/utils";
-import { usePathname } from "next/navigation";
 import {
   BASE_ASSET_URL,
-  type VersionManifestEntry,
 } from "~/server/java/versions";
 import type { ClassValue } from "clsx";
+import { VersionEntry } from "~/app/java/changelog/layout";
 
 export default function VersionLink({
-  versionName,
-  versionLink = versionName,
-  data: { shortText, title, image },
+  version,
   className = "px-3 py-1",
+  selected
 }: {
-  versionName: string;
-  versionLink?: string;
-  data: VersionManifestEntry;
+  version: VersionEntry;
   className?: ClassValue;
+  selected: boolean;
 }) {
-  const url = `/java/changelog/${versionLink}`;
-  const pathname = usePathname();
-  const selected = url === pathname || url === pathname + "/";
-
+  const url = `/java/changelog/${version.url}`;
   return (
     <HoverCard closeDelay={0} openDelay={0}>
       <HoverCardTrigger asChild>
         <Link
           href={url}
           className={cn(
-            "inline-block w-full text-subtext1 hover:bg-surface1",
+            "inline-block w-full text-subtext1 hover:bg-surface1 version-label",
             { "bg-surface0 underline": selected },
             className,
           )}
           prefetch={false}
         >
-          {versionName}
+          {version.name}
         </Link>
       </HoverCardTrigger>
       <HoverCardPortal>
@@ -53,11 +47,11 @@ export default function VersionLink({
           <div
             className="absolute inset-0 -z-10 rounded-md bg-cover bg-center opacity-20"
             style={{
-              backgroundImage: `url(${BASE_ASSET_URL + image.url})`,
+              backgroundImage: `url(${BASE_ASSET_URL + version.image.url})`,
             }}
           />
-          <h2>{title}</h2>
-          <p>{shortText}…</p>
+          <h2>{version.title}</h2>
+          <p>{version.description}…</p>
         </HoverCardContent>
       </HoverCardPortal>
     </HoverCard>

--- a/src/components/java/version-link.tsx
+++ b/src/components/java/version-link.tsx
@@ -12,7 +12,6 @@ import {
   BASE_ASSET_URL,
 } from "~/server/java/versions";
 import type { ClassValue } from "clsx";
-import { VersionEntry } from "~/app/java/changelog/layout";
 
 export default function VersionLink({
   version,
@@ -56,4 +55,17 @@ export default function VersionLink({
       </HoverCardPortal>
     </HoverCard>
   );
+}
+
+export interface VersionEntry {
+  name: string;
+  url: string;
+  title: string;
+  description: string;
+  image: { title: string; url: string; };
+}
+
+export interface ReleaseVersionEntry extends VersionEntry {
+  nonReleaseVersions: VersionEntry[];
+  isLatest: boolean;
 }

--- a/src/styles/arrow_down.svg
+++ b/src/styles/arrow_down.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
-  <path d="m 0 5  l 2 -2  l 6 6  l 6 -6  l 2 2 l -8 8 z" fill="black" />
+  <path d="m 0 5  l 2 -2  l 6 6  l 6 -6  l 2 2 l -8 8 z" />
 </svg>

--- a/src/styles/arrow_down.svg
+++ b/src/styles/arrow_down.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+  <path d="m 0 5  l 2 -2  l 6 6  l 6 -6  l 2 2 l -8 8 z" fill="black" />
+</svg>

--- a/src/styles/arrow_up.svg
+++ b/src/styles/arrow_up.svg
@@ -1,3 +1,3 @@
 <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
-  <path d="m 0 11  l 2 2  l 6 -6  l 6 6  l 2 -2 l -8 -8 z" fill="black" />
+  <path d="m 0 11  l 2 2  l 6 -6  l 6 6  l 2 -2 l -8 -8 z" />
 </svg>

--- a/src/styles/arrow_up.svg
+++ b/src/styles/arrow_up.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg">
+  <path d="m 0 11  l 2 2  l 6 -6  l 6 6  l 2 -2 l -8 -8 z" fill="black" />
+</svg>

--- a/src/styles/game-versions.css
+++ b/src/styles/game-versions.css
@@ -28,12 +28,12 @@
   aspect-ratio: 1 / 1;
   align-self: center;
   grid-area: button;
-  background-image: url("arrow_down.svg");
-  background-size: cover;
+  mask-image: url("arrow_down.svg");
+  background-color: rgb(var(--ctp-subtext1));
 }
 
 input:checked + .major-version-button {
-  background-image: url("arrow_up.svg");
+  mask-image: url("arrow_up.svg");
 }
 
 .major-version-body {

--- a/src/styles/game-versions.css
+++ b/src/styles/game-versions.css
@@ -1,0 +1,47 @@
+.versions {
+  display: flex;
+  flex-direction: column;
+  margin-left: 0.5em;
+  user-select: none;
+}
+
+.versions input {
+  display: none;
+}
+
+.major-version {
+  display: grid;
+  gap: 0 0.5em;
+  grid-template-rows: auto 1fr;
+  grid-template-columns: 1em 1fr;
+  grid-template-areas:
+    "button title"
+    ". body";
+}
+
+.major-version > .version-label {
+  grid-area: title;
+  font-weight: bold;
+}
+
+.major-version-button {
+  aspect-ratio: 1 / 1;
+  align-self: center;
+  grid-area: button;
+  background-image: url("arrow_down.svg");
+  background-size: cover;
+}
+
+input:checked + .major-version-button {
+  background-image: url("arrow_up.svg");
+}
+
+.major-version-body {
+  grid-area: body;
+  display: none;
+}
+
+input:checked ~ .major-version-body {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION
Groups and collapses the version bar by each release for the articles. They only go down a single level because people don't like going down too many levels (better UX), because Mojang's drop system usually increments the same version number as the one they increment for hotfixes (e.g. 1.21.9 and 1.21.10) and because that is what is classified as a stable version.